### PR TITLE
Remove ...::changemediaplayer method

### DIFF
--- a/modules/ugdk-core/include/ugdk/action/mediaplayer.h
+++ b/modules/ugdk-core/include/ugdk/action/mediaplayer.h
@@ -36,8 +36,6 @@ class MediaPlayer {
 
     void AddTickFunction(std::function<void (void)> tick);
 
-    void ChangeMediaManager(MediaManager*);
-
   protected:
     void notifyAllObservers();
 

--- a/modules/ugdk-core/src/action/mediaplayer.cc
+++ b/modules/ugdk-core/src/action/mediaplayer.cc
@@ -18,10 +18,6 @@ void MediaPlayer::AddTickFunction(std::function<void (void)> tick) {
     ticks_.push_back(tick);
 }
 
-void MediaPlayer::ChangeMediaManager(MediaManager* manager) {
-    manager->AddPlayer(this); // This function changes mangaer_
-}
-
 void MediaPlayer::notifyAllObservers() {
     for (const auto& tick : ticks_) {
         tick();


### PR DESCRIPTION
Removes a single redundant method and its implementation in the action::MediaManager namespace