### PR TITLE
[WIP] Fit json loader into resource container protocol

### DIFF
--- a/modules/ugdk-core/include/ugdk/action/json2spriteanimation.h
+++ b/modules/ugdk-core/include/ugdk/action/json2spriteanimation.h
@@ -16,7 +16,7 @@ namespace action {
 
 using SpriteAnimationTable = ::ugdk::structure::IndexableTable<SpriteAnimation>;
 
-std::shared_ptr<const SpriteAnimationTable> LoadSpriteAnimationTableFromFile(const std::string& filepath);
+const SpriteAnimationTable* LoadSpriteAnimationTableFromFile(const std::string& filepath);
 
 }  // namespace action
 }  // namespace ugdk

--- a/modules/ugdk-core/src/action/json2spriteanimation.cc
+++ b/modules/ugdk-core/src/action/json2spriteanimation.cc
@@ -71,7 +71,7 @@ namespace {
     };
 }
 
-std::shared_ptr<const SpriteAnimationTable> LoadSpriteAnimationTableFromFile(const std::string& filepath) {
+const SpriteAnimationTable* LoadSpriteAnimationTableFromFile(const std::string& filepath) {
     auto file = filesystem::manager().OpenFile(filepath);
     if (!file)
         return nullptr;
@@ -81,7 +81,7 @@ std::shared_ptr<const SpriteAnimationTable> LoadSpriteAnimationTableFromFile(con
         throw system::BaseException("Invalid json: %s\n", filepath.c_str());
 
     auto json_node = libjson::parse(contents);
-    std::shared_ptr<SpriteAnimationTable> table(new SpriteAnimationTable(json_node.size()));
+    SpriteAnimationTable* table(new SpriteAnimationTable(json_node.size()));
     for (const auto& animation_json : json_node) {
         auto element = MakeUnique<SpriteAnimation>();
 
@@ -108,4 +108,3 @@ std::shared_ptr<const SpriteAnimationTable> LoadSpriteAnimationTableFromFile(con
 
 }  // namespace action
 }  // namespace ugdk
-


### PR DESCRIPTION
This PR is not ready to merge yet.

We need to:
1. Define a `ResourceLoader<T>` class which is to be overloaded for the appropriate types
2. Change the default constructor of `ResourceContainer<T>` to delegate resource loading to the corresponding `ResourceLoader<T>`
3. Find a place to define `ResourceLoader<SpriteAnimationTable>` while moving `action/json2spriteanimation.h` out of the public API.

This way, the default loader for animation tables becomes the JSON loader, but the developer can still pass their own loader to `ResourceLoader`.