### PR TITLE
Add Mesh class

### DIFF
--- a/modules/ugdk-core/include/ugdk/graphic/canvas.h
+++ b/modules/ugdk-core/include/ugdk/graphic/canvas.h
@@ -17,14 +17,14 @@
 namespace ugdk {
 namespace graphic {
 
-/**
-    Binds the RenderTarget to allow rendering. Unbinds automatically on destructor.
-    Creating multiple instances at the same time are supported, but the lifetime of
-    the instances should act as a stack.
-    TODO: example about this.
-
-    The only valid calls on inactive instances are const-qualified methods.
-*/
+/// Graphics rendering interface
+/** Binds the RenderTarget to allow rendering. Unbinds automatically on destructor.
+ *  Creating multiple instances at the same time are supported, but the lifetime of
+ *  the instances should act as a stack.
+ *  TODO: example about this.
+ *
+ *  The only valid calls on inactive instances are const-qualified methods.
+ */
 class Canvas {
   public:
     Canvas(RenderTarget* render_target);

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -1,1 +1,42 @@
-// continue here
+
+#ifndef UGDK_GRAPHIC_MESH_H_
+#define UGDK_GRAPHIC_MESH_H_
+
+#include <ugdk/graphic/vertexdata.h>
+
+#include <glm/vec2.hpp>
+
+#include <vector>
+
+namespace ugdk {
+namespace graphic {
+
+class Canvas;
+
+template <typename Position, typename Texel>
+class Mesh {
+  public:
+    struct Vertex {
+      Position  pos;
+      Texel     tex;
+    };
+    Mesh(const DrawMode& the_mode, const std::vector<Vertex>& the_vtx_data);
+    Mesh(const Mesh& rhs) = delete;
+    Mesh& operator=(const Mesh& rhs) = delete;
+    Mesh(Mesh&& rhs);
+    Mesh& operator=(Mesh&& rhs);
+  private:
+    friend Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
+    DrawMode    mode_;
+    VertexData  vtx_data_;
+};
+
+using MeshXYUV = Mesh<glm::vec2, glm::vec2>;
+
+template <typename Position, typename Texel>
+Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
+
+} // namespace ugdk
+} // namespace graphic
+
+#endif // UGDK_GRAPHIC_MESH_H_

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -35,10 +35,10 @@ class Mesh {
 
     /// 
     void Fill(const VertexArray& vertices);
+
+    void StreamTo(Canvas &canvas) const;
     
   private:
-    template <typename T>
-    friend Canvas& operator<<(Canvas &canvas, const Mesh<T> &mesh);
     DrawMode            mode_;
     GLTexture           *texture_;
     std::vector<Vertex> vertices_;
@@ -57,23 +57,26 @@ inline void Mesh<Vertex>::Fill(const Mesh<Vertex>::VertexArray& vertices) {
 
 template <typename Vertex>
 Canvas& operator<<(Canvas &canvas, const Mesh<Vertex> &mesh) {
+    mesh.StreamTo(canvas);
     return canvas;
 }
 
+template <typename Vertex>
+void Mesh<Vertex>::StreamTo(Canvas &canvas) const {}
+
 template <>
-Canvas& operator<<(Canvas &canvas, const Mesh<structure::VertexXYUV> &mesh) {
-    VertexData vtxdata(mesh.vertices_.size(), sizeof(structure::VertexXYUV), false, true);
+void Mesh<structure::VertexXYUV>::StreamTo(Canvas &canvas) const {
+    VertexData vtxdata(this->vertices_.size(), sizeof(structure::VertexXYUV), false, true);
     {
         VertexData::Mapper<structure::VertexXYUV> map(vtxdata);
-        for (size_t i = 0; i < mesh.vertices_.size(); i++)
-            map.Get(i) = mesh.vertices_[i];
+        for (size_t i = 0; i < this->vertices_.size(); i++)
+            map.Get(i) = this->vertices_[i];
     }
-    graphic::TextureUnit unit = graphic::manager().ReserveTextureUnit(mesh.texture_);
+    graphic::TextureUnit unit = graphic::manager().ReserveTextureUnit(this->texture_);
     canvas.SendUniform("drawable_texture", unit);
     canvas.SendVertexData(vtxdata, graphic::VertexType::VERTEX, 0, 2);
     canvas.SendVertexData(vtxdata, graphic::VertexType::TEXTURE, 2 * sizeof(F32), 2);
-    canvas.DrawArrays(mesh.mode_, 0, mesh.vertices_.size());
-    return canvas;
+    canvas.DrawArrays(this->mode_, 0, this->vertices_.size());
 }
 
 } // namespace ugdk

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -30,6 +30,9 @@ class Mesh {
     /// Alias
     using VertexArray = std::vector<Vertex>;
 
+    /// Default constructor (an invalid mesh)
+    Mesh();
+
     /// Construct mesh with given draw mode
     Mesh(const DrawMode& the_mode, GLTexture* the_texture);
 
@@ -45,6 +48,9 @@ class Mesh {
 };
 
 using Mesh2D = Mesh<structure::VertexXYUV>;
+
+template <typename Vertex>
+inline Mesh<Vertex>::Mesh() : Mesh(DrawMode::TRIANGLES(), nullptr) {}
 
 template <typename Vertex>
 inline Mesh<Vertex>::Mesh(const DrawMode& the_mode, GLTexture* the_texture)

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -3,6 +3,8 @@
 #define UGDK_GRAPHIC_MESH_H_
 
 #include <ugdk/structure/vertex.h>
+#include <ugdk/graphic/canvas.h>
+#include <ugdk/graphic/module.h>
 #include <ugdk/graphic/vertexdata.h>
 #include <ugdk/graphic.h>
 
@@ -17,7 +19,7 @@ class Canvas;
 
 // TODO:
 // + [x] Add fill methods
-// + [ ] Write stream method
+// + [x] Write stream method
 // Remember:
 // + VertexData will be used internally to group buffers
 // + Mesh is used by user for easy access
@@ -44,16 +46,17 @@ class Mesh {
 
 using Mesh2D = Mesh<structure::VertexXYUV>;
 
-inline Mesh::Mesh(const DrawMode& the_mode, GLTexture* the_texture)
+template <typename Vertex>
+inline Mesh<Vertex>::Mesh(const DrawMode& the_mode, GLTexture* the_texture)
     : mode_(the_mode), texture_(the_texture) {}
 
-inline void Mesh::Fill(const VertexArray& vertices) {
+template <typename Vertex>
+inline void Mesh<Vertex>::Fill(const Mesh<Vertex>::VertexArray& vertices) {
     vertices_ = vertices;
 }
 
 template <typename Vertex>
 Canvas& operator<<(Canvas &canvas, const Mesh<Vertex> &mesh) {
-    static_assert<false>;
     return canvas;
 }
 
@@ -61,7 +64,7 @@ template <>
 Canvas& operator<<(Canvas &canvas, const Mesh<structure::VertexXYUV> &mesh) {
     VertexData vtxdata(mesh.vertices_.size(), sizeof(structure::VertexXYUV), false, true);
     {
-        VertexData::Mapper<Vertex> map(vtxdata);
+        VertexData::Mapper<structure::VertexXYUV> map(vtxdata);
         for (size_t i = 0; i < mesh.vertices_.size(); i++)
             map.Get(i) = mesh.vertices_[i];
     }

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -1,0 +1,1 @@
+// continue here

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -13,6 +13,9 @@ namespace graphic {
 
 class Canvas;
 
+// TODO
+// Make VertexData::Mapper template, delegating bind/unbind to VertexData
+
 template <typename Position, typename Texel>
 class Mesh {
   public:
@@ -25,6 +28,7 @@ class Mesh {
     Mesh& operator=(const Mesh& rhs) = delete;
     Mesh(Mesh&& rhs);
     Mesh& operator=(Mesh&& rhs);
+    
   private:
     friend Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
     DrawMode    mode_;

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -2,7 +2,7 @@
 #ifndef UGDK_GRAPHIC_MESH_H_
 #define UGDK_GRAPHIC_MESH_H_
 
-#include <ugdk/graphic/vertexdata.h>
+#include <ugdk/structure/vertex.h>
 
 #include <glm/vec2.hpp>
 
@@ -13,29 +13,25 @@ namespace graphic {
 
 class Canvas;
 
-// TODO
-// Make VertexData::Mapper template, delegating bind/unbind to VertexData
-
-template <typename Position, typename Texel>
+template <typename Vertex>
 class Mesh {
   public:
-    struct Vertex {
-      Position  pos;
-      Texel     tex;
-    };
-    Mesh(const DrawMode& the_mode, const std::vector<Vertex>& the_vtx_data);
-    Mesh(const Mesh& rhs) = delete;
-    Mesh& operator=(const Mesh& rhs) = delete;
-    Mesh(Mesh&& rhs);
-    Mesh& operator=(Mesh&& rhs);
+    /// Alias
+    using VertexArray = std::vector<Vertex>;
+
+    /// Construct mesh with given draw mode
+    Mesh(const DrawMode& the_mode);
+
+    /// 
+    void Fill(const VertexArray& vertices);
     
   private:
     friend Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
-    DrawMode    mode_;
-    VertexData  vtx_data_;
+    DrawMode            mode_;
+    std::vector<Vertex> vtx_data_;
 };
 
-using MeshXYUV = Mesh<glm::vec2, glm::vec2>;
+using Mesh2D = Mesh<structure::VertexXYUV>;
 
 template <typename Position, typename Texel>
 Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -75,8 +75,13 @@ Canvas& operator<<(Canvas &canvas, const Mesh<Vertex> &mesh) {
     return canvas;
 }
 
+/// See https://stackoverflow.com/questions/8854286/how-to-enforce-use-of-template-specialization
+template<typename T> struct fake_dependency: public std::false_type {};
+
 template <typename Vertex>
-void Mesh<Vertex>::StreamTo(Canvas &canvas) const {}
+void Mesh<Vertex>::StreamTo(Canvas &canvas) const {
+    static_assert(fake_dependency<Vertex>::value, "must use specialization");
+}
 
 template <>
 void Mesh<structure::VertexXYUV>::StreamTo(Canvas &canvas) const {

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -3,6 +3,8 @@
 #define UGDK_GRAPHIC_MESH_H_
 
 #include <ugdk/structure/vertex.h>
+#include <ugdk/graphic/vertexdata.h>
+#include <ugdk/graphic.h>
 
 #include <glm/vec2.hpp>
 
@@ -13,6 +15,13 @@ namespace graphic {
 
 class Canvas;
 
+// TODO:
+// + [x] Add fill methods
+// + [ ] Write stream method
+// Remember:
+// + VertexData will be used internally to group buffers
+// + Mesh is used by user for easy access
+
 template <typename Vertex>
 class Mesh {
   public:
@@ -20,21 +29,30 @@ class Mesh {
     using VertexArray = std::vector<Vertex>;
 
     /// Construct mesh with given draw mode
-    Mesh(const DrawMode& the_mode);
+    Mesh(const DrawMode& the_mode, GLTexture* the_texture);
 
     /// 
     void Fill(const VertexArray& vertices);
     
   private:
-    friend Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
+    template <typename T>
+    friend Canvas& operator<<(Canvas &canvas, const Mesh<T> &mesh);
     DrawMode            mode_;
+    GLTexture           *texture_;
     std::vector<Vertex> vtx_data_;
 };
 
 using Mesh2D = Mesh<structure::VertexXYUV>;
 
-template <typename Position, typename Texel>
-Canvas& operator<<(Canvas &canvas, const Mesh<Position, Texel> &mesh);
+inline Mesh::Mesh(const DrawMode& the_mode, GLTexture* the_texture)
+    : mode_(the_mode), texture_(the_texture) {}
+
+inline void Mesh::Fill(const VertexArray& vertices) {
+    vtx_data_ = vertices;
+}
+
+template <typename Vertex>
+Canvas& operator<<(Canvas &canvas, const Mesh<Vertex> &mesh);
 
 } // namespace ugdk
 } // namespace graphic

--- a/modules/ugdk-core/include/ugdk/graphic/mesh.h
+++ b/modules/ugdk-core/include/ugdk/graphic/mesh.h
@@ -36,6 +36,9 @@ class Mesh {
     /// Construct mesh with given draw mode
     Mesh(const DrawMode& the_mode, GLTexture* the_texture);
 
+    /// Tells whether the Mesh is valid
+    bool valid() const;
+
     /// 
     void Fill(const VertexArray& vertices);
 
@@ -55,6 +58,11 @@ inline Mesh<Vertex>::Mesh() : Mesh(DrawMode::TRIANGLES(), nullptr) {}
 template <typename Vertex>
 inline Mesh<Vertex>::Mesh(const DrawMode& the_mode, GLTexture* the_texture)
     : mode_(the_mode), texture_(the_texture) {}
+
+template <typename Vertex>
+inline bool Mesh<Vertex>::valid() const {
+    return static_cast<bool>(this->texture_);
+}
 
 template <typename Vertex>
 inline void Mesh<Vertex>::Fill(const Mesh<Vertex>::VertexArray& vertices) {

--- a/modules/ugdk-core/include/ugdk/graphic/vertexdata.h
+++ b/modules/ugdk-core/include/ugdk/graphic/vertexdata.h
@@ -3,6 +3,7 @@
 
 #include <ugdk/graphic.h>
 #include <ugdk/structure/types.h>
+#include <ugdk/system/exceptions.h>
 
 #include <cstddef>
 #include <memory>
@@ -14,44 +15,93 @@ namespace graphic {
 class VertexBuffer;
 struct VertexDataSpecification;
 
+/// Holds vertex data for rendering
 class VertexData {
   public:
-    class Mapper {
-    public:
-        Mapper(VertexData& data, bool read_from_buffer = true);
-        ~Mapper();
+    template <typename T>
+    class Mapper;
 
-        void operator=(Mapper&) = delete;
-
-        template<class T>
-        T& Get(std::size_t index) {
-            Validate(typeid(T).name(), sizeof(T), index);
-            return *reinterpret_cast<T*>(mapped_ + index * data_.vertex_size());
-        }
-
-    private:
-        VertexData& data_;
-        ugdk::uint8* mapped_;
-
-        void Validate(const char* name, std::size_t size, std::size_t index) const;
-    };
-
+    /// Contructs empty data
     VertexData();
+
+    /// Copy constructor
     VertexData(VertexData&& rhs);
-    explicit VertexData(std::size_t num_vertices, std::size_t vertex_size, bool dynamic, bool ignore_vbo = false);
+
+    /// Constructs vertex data
+    explicit VertexData(std::size_t num_vertices, std::size_t vertex_size, bool dynamic,
+                        bool ignore_vbo = false);
+
+    /// Constructs vertex data from specification
     explicit VertexData(const VertexDataSpecification&);
+
+    /// Destructor
     ~VertexData();
 
+    /// Access internal vertex buffer #FIXME
     const std::unique_ptr<VertexBuffer>& buffer() const { return buffer_; }
+
+    /// Get total vertex count
     std::size_t num_vertices() const { return num_vertices_; }
+
+    /// Get individual vertex size
     std::size_t vertex_size() const { return vertex_size_; }
 
-    void CheckSizes(const char* caller_name, std::size_t test_num_vertices, std::size_t test_vertex_size) const;
+    /// Check whether given amount of data fits
+    void CheckSizes(const char* caller_name, std::size_t test_num_vertices,
+                    std::size_t test_vertex_size) const;
 
   private:
+    template <typename T>
+    friend class Mapper;
+
+    /// Returns an array mapping the contents of the bufffer
+    ugdk::uint8* Map(bool read_from_buffer);
+
+    /// Unmaps data acquired from VertexData::Map, flushing to buffer
+    void Unmap();
+
     std::unique_ptr<VertexBuffer> buffer_;
     std::size_t num_vertices_;
     std::size_t vertex_size_;
+};
+
+/// Used to read and write vertices in a VertexData object
+template <typename T>
+class VertexData::Mapper {
+  public:
+    /// Constructs mapper, attaching it to given VertexData object with RAII
+    Mapper(VertexData& data, bool read_from_buffer = true) 
+        : data_(data), mapped_(data.Map(read_from_buffer)) {}
+
+    /// RAII destruction
+    ~Mapper() {
+        data_.Unmap();
+    }
+
+    /// Deleted copy operator
+    void operator=(Mapper&) = delete;
+
+    /// Accesses a specific chunk of vertex data as a T object
+    T& Get(std::size_t index) {
+        Validate(typeid(T).name(), sizeof(T), index);
+        return *reinterpret_cast<T*>(mapped_ + index * data_.vertex_size());
+    }
+
+  private:
+    void Validate(const char* name, std::size_t size, std::size_t index) const {
+        if (size > data_.vertex_size())
+            throw system::BaseException(
+                "Incompatible type '%s' with size %u exceeds vertex buffer size of %u.",
+                name, size, data_.vertex_size()
+            );
+        if (index >= data_.num_vertices())
+            throw system::BaseException("Vertex %u is out of range. (Buffer has %u vertices)",
+                                        index, data_.num_vertices());
+    }
+
+    VertexData& data_;
+    ugdk::uint8* mapped_;
+
 };
 
 struct VertexDataSpecification {

--- a/modules/ugdk-core/include/ugdk/graphic/vertexdata.h
+++ b/modules/ugdk-core/include/ugdk/graphic/vertexdata.h
@@ -24,7 +24,7 @@ class VertexData {
     /// Contructs empty data
     VertexData();
 
-    /// Copy constructor
+    /// Move constructor
     VertexData(VertexData&& rhs);
 
     /// Constructs vertex data

--- a/modules/ugdk-core/include/ugdk/math/geometry.h
+++ b/modules/ugdk-core/include/ugdk/math/geometry.h
@@ -26,7 +26,7 @@ class Geometry {
      ** @param rot Rotation angle in radians. 0 points to the right, increases in
      ** counterclockwise fashion.
      */
-    Geometry(const glm::vec2& offset, const glm::vec2& scale = {1.0f, 1.0f}, double rot = 0.0)
+    Geometry(const glm::dvec2& offset, const glm::dvec2& scale = {1.0f, 1.0f}, double rot = 0.0)
     : rotation_(-rot),
     matrix_(float(scale.x*cos(-rot)), -float(scale.x*sin(-rot)), 0.0f, 0.0f, // First column
     float(scale.y*sin(-rot)),  float(scale.y*cos(-rot)), 0.0f, 0.0f,

--- a/modules/ugdk-core/include/ugdk/math/geometry.h
+++ b/modules/ugdk-core/include/ugdk/math/geometry.h
@@ -7,6 +7,7 @@
 #define GLM_FORCE_RADIANS
 #include <glm/glm.hpp>
 #include <glm/ext.hpp>
+#include <glm/vec2.hpp>
 
 
 namespace ugdk {
@@ -17,21 +18,24 @@ class Geometry {
     /// Creates an identity Geometry;
     Geometry() : rotation_(0.0), matrix_(1.0f) {}
 
-    ///Creates a new Geometry object with the specified values. 
+    /// Creates a new Geometry object with the specified values. 
     /**
-     * @param offset The offset of the image.
-     * @param scale The size modifiers for the image. X and Y values can be set
-     * independently.
-     * @param rot Rotation angle in radians. 0 points to the right, increases in
-     * counterclockwise fashion.
+     ** @param offset The offset of the image.
+     ** @param scale The size modifiers for the image. X and Y values can be set
+     ** independently.
+     ** @param rot Rotation angle in radians. 0 points to the right, increases in
+     ** counterclockwise fashion.
      */
-    Geometry(const math::Vector2D& offset, const math::Vector2D scale = math::Vector2D(1.0, 1.0), double rot = 0.0)
+    Geometry(const glm::vec2& offset, const glm::vec2& scale = {1.0f, 1.0f}, double rot = 0.0)
     : rotation_(-rot),
-      matrix_(float(scale.x*cos(-rot)), -float(scale.x*sin(-rot)), 0.0f, 0.0f, // First column
-              float(scale.y*sin(-rot)),  float(scale.y*cos(-rot)), 0.0f, 0.0f,
-                                 0.0f,                     0.0f, 1.0f, 0.0f,
-                      float(offset.x),          float(offset.y), 0.0f, 1.0f) {}
-
+    matrix_(float(scale.x*cos(-rot)), -float(scale.x*sin(-rot)), 0.0f, 0.0f, // First column
+    float(scale.y*sin(-rot)),  float(scale.y*cos(-rot)), 0.0f, 0.0f,
+    0.0f,                      0.0f, 1.0f, 0.0f,
+    float(offset.x),           float(offset.y), 0.0f, 1.0f) {}
+    
+    Geometry(const math::Vector2D& offset, const math::Vector2D scale = math::Vector2D(1.0, 1.0), double rot = 0.0)
+    : Geometry(glm::vec2(offset.x, offset.y), glm::vec2(scale.x, scale.y), rot) {}
+    
     // Destructor
     ~Geometry() {}
 

--- a/modules/ugdk-core/include/ugdk/math/vector2D.h
+++ b/modules/ugdk-core/include/ugdk/math/vector2D.h
@@ -38,7 +38,7 @@ class Vector2D {
     explicit Vector2D(const math::Integer2D& int2d);
 
     /// Copy constructor from glm::vec2
-    Vector2D(const glm::vec2 rhs) : x(rhs.x), y(rhs.y) {}
+    Vector2D(const glm::dvec2 rhs) : x(rhs.x), y(rhs.y) {}
 
     ~Vector2D() { }
 
@@ -191,6 +191,13 @@ class Vector2D {
         return a.Rotate(angle);
     }
 
+
+    /// Copies data from a glm::dvec2
+    Vector2D& operator=(const glm::dvec2& rhs) {
+        x = rhs.x;
+        y = rhs.y;
+        return *this;
+    }
 
 	/// Compares this vector to the given vector, return True if they are equivalent.
 		/** Two vectors are equivalent if the coordinates are equal.

--- a/modules/ugdk-core/include/ugdk/math/vector2D.h
+++ b/modules/ugdk-core/include/ugdk/math/vector2D.h
@@ -4,6 +4,9 @@
 
 #include <ugdk/structure/types.h>
 #include <ugdk/math.h>
+
+#include <glm/vec2.hpp>
+
 #include <array>
 #include <tuple>
 
@@ -33,6 +36,9 @@ class Vector2D {
 
     /// Copy constructor from Integer2D.
     explicit Vector2D(const math::Integer2D& int2d);
+
+    /// Copy constructor from glm::vec2
+    Vector2D(const glm::vec2 rhs) : x(rhs.x), y(rhs.y) {}
 
     ~Vector2D() { }
 

--- a/modules/ugdk-core/include/ugdk/structure/types.h
+++ b/modules/ugdk-core/include/ugdk/structure/types.h
@@ -6,6 +6,7 @@
 namespace ugdk {
 
 using F32 = float;
+using F64 = double;
 
 typedef uint8_t uint8;
 typedef uint16_t uint16;

--- a/modules/ugdk-core/include/ugdk/structure/vertex.h
+++ b/modules/ugdk-core/include/ugdk/structure/vertex.h
@@ -2,16 +2,19 @@
 #ifndef UGDK_STRUCTURE_VERTEX_H_
 #define UGDK_STRUCTURE_VERTEX_H_
 
+#include <ugdk/structure/types.h>
+
 #include <glm/vec2.hpp>
 
 namespace ugdk {
 namespace structure {
 
 struct VertexXYUV {
-    float x;
-    float y;
-    float u;
-    float v;
+
+    F32 x;
+    F32 y;
+    F32 u;
+    F32 v;
     
     void set_xyuv(float _x, float _y, float _u, float _v) {
         x = _x;

--- a/modules/ugdk-core/include/ugdk/structure/vertex.h
+++ b/modules/ugdk-core/include/ugdk/structure/vertex.h
@@ -1,5 +1,8 @@
+
 #ifndef UGDK_STRUCTURE_VERTEX_H_
 #define UGDK_STRUCTURE_VERTEX_H_
+
+#include <glm/vec2.hpp>
 
 namespace ugdk {
 namespace structure {
@@ -15,6 +18,15 @@ struct VertexXYUV {
         y = _y;
         u = _u;
         v = _v;
+    }
+    void set(const glm::vec2& xy) {
+        x = xy.x;
+        y = xy.y;
+    }
+    void set(const glm::vec2& xy, const glm::vec2& uv) {
+        set(xy);
+        u = uv.x;
+        v = uv.y;
     }
 };
 

--- a/modules/ugdk-core/include/ugdk/text/functions.h
+++ b/modules/ugdk-core/include/ugdk/text/functions.h
@@ -9,7 +9,7 @@
 namespace ugdk {
 namespace text {
 
-float FillBufferWithText(const Font*, const std::u32string&, graphic::VertexData::Mapper& mapped_data, float y = 0.0f);
+float FillBufferWithText(const Font*, const std::u32string&, graphic::VertexData& vtx_data, float y = 0.0f);
 
 void DrawTextLine(graphic::Canvas& canvas, const Font*, const std::string& utf8_message);
 

--- a/modules/ugdk-core/src/graphic/vertexdata.cc
+++ b/modules/ugdk-core/src/graphic/vertexdata.cc
@@ -6,27 +6,6 @@
 namespace ugdk {
 namespace graphic {
 
-VertexData::Mapper::Mapper(VertexData& data, bool read_from_buffer)
-: data_(data)
-{
-    data.buffer()->bind();
-    mapped_ = static_cast<uint8*>(data.buffer()->map(read_from_buffer));
-    internal::AssertNoOpenGLError();
-}
-
-VertexData::Mapper::~Mapper() {
-    data_.buffer()->unmap();
-    data_.buffer()->unbind();
-}
-
-void VertexData::Mapper::Validate(const char* name, std::size_t size, std::size_t index) const {
-    if (size > data_.vertex_size())
-        throw system::BaseException("Incompatible type '%s' with size %u exceeds vertex buffer size of %u.", name, size, data_.vertex_size());
-
-    if (index >= data_.num_vertices())
-        throw system::BaseException("Vertex %u is out of range. (Buffer has %u vertices)", index, data_.num_vertices());
-}
-
 VertexData::VertexData() : num_vertices_(0u), vertex_size_(0u) {}
 
 VertexData::VertexData(VertexData&& rhs)
@@ -62,6 +41,18 @@ void VertexData::CheckSizes(const char* caller_name, std::size_t test_num_vertic
 
     if (test_vertex_size > 0 && vertex_size_ < test_vertex_size)
         throw system::BaseException("Unsufficient vertex size for %s. Needs %u bytes, found %u.", caller_name, test_vertex_size, vertex_size_);
+}
+
+ugdk::uint8* VertexData::Map(bool read_from_buffer) {
+    buffer_->bind();
+    ugdk::uint8* mapped = static_cast<uint8*>(buffer_->map(read_from_buffer));
+    internal::AssertNoOpenGLError();
+    return mapped;
+}
+
+void VertexData::Unmap() {
+    buffer_->unmap();
+    buffer_->unbind();
 }
 
 }  // namespace graphic

--- a/modules/ugdk-core/src/text/functions.cc
+++ b/modules/ugdk-core/src/text/functions.cc
@@ -25,9 +25,10 @@ namespace {
     std::unique_ptr<VertexData> square_data_;
 }
 
-float FillBufferWithText(const Font* font, const std::u32string& msg, VertexData::Mapper& mapped_data, float y) {
+float FillBufferWithText(const Font* font, const std::u32string& msg, VertexData& vtx_data, float y) {
     float pen = 0.0f;
     size_t buffer_offset = 0;
+    VertexData::Mapper<VertexXYUV> mapped_data(vtx_data, false);
     for(size_t i = 0; i < msg.size(); ++i ) {
         texture_glyph_t *glyph = texture_font_get_glyph(font->freetype_font(),
                                                         static_cast<wchar_t>(msg[i]));
@@ -44,25 +45,25 @@ float FillBufferWithText(const Font* font, const std::u32string& msg, VertexData
         y0 = y + font->freetype_font()->height - y0;
         y1 = y + font->freetype_font()->height - y1;
         {
-            VertexXYUV &v1 = mapped_data.Get<VertexXYUV>(buffer_offset + 0);
+            VertexXYUV &v1 = mapped_data.Get(buffer_offset + 0);
             v1.x = x0;
             v1.y = y0;
             v1.u = glyph->s0;
             v1.v = glyph->t0;
 
-            VertexXYUV &v2 = mapped_data.Get<VertexXYUV>(buffer_offset + 1);
+            VertexXYUV &v2 = mapped_data.Get(buffer_offset + 1);
             v2.x = x1;
             v2.y = y0;
             v2.u = glyph->s1;
             v2.v = glyph->t0;
 
-            VertexXYUV &v3 = mapped_data.Get<VertexXYUV>(buffer_offset + 2);
+            VertexXYUV &v3 = mapped_data.Get(buffer_offset + 2);
             v3.x = x0;
             v3.y = y1;
             v3.u = glyph->s0;
             v3.v = glyph->t1;
 
-            VertexXYUV &v4 = mapped_data.Get<VertexXYUV>(buffer_offset + 3);
+            VertexXYUV &v4 = mapped_data.Get(buffer_offset + 3);
             v4.x = x1;
             v4.y = y1;
             v4.u = glyph->s1;
@@ -79,10 +80,7 @@ void DrawTextLine(Canvas& canvas, const Font* font, const std::string& utf8_mess
     auto ucs_msg = utf8_to_ucs4(utf8_message);
 
     VertexData data(utf8_message.size() * 4, sizeof(VertexXYUV), false, true);
-    {
-        VertexData::Mapper mapper(data);
-        FillBufferWithText(font, ucs_msg, mapper);
-    }
+    FillBufferWithText(font, ucs_msg, data);
 
     std::vector<int> first_vector;
     first_vector.reserve(ucs_msg.size());

--- a/modules/ugdk-core/src/text/label.cc
+++ b/modules/ugdk-core/src/text/label.cc
@@ -50,11 +50,7 @@ void Label::ChangeMessage(const std::u32string& ucs4_message) {
     size_ = math::Vector2D(0, font_->height());
 
     buffer_.reset(new VertexData(num_characters_ * 4, 2 * sizeof(vec2), false));
-    {
-        // Leaving the buffer bound may cause texture_font_get_glyph to crash.
-        VertexData::Mapper mapper(*buffer_);
-        size_.x = FillBufferWithText(font_, ucs4_message, mapper, 0.0f);
-    }
+    size_.x = FillBufferWithText(font_, ucs4_message, *buffer_, 0.0f);
 
     first_vector_.reserve(num_characters_);
     for(size_t i = 0; i < num_characters_; ++i )


### PR DESCRIPTION
It holds the draw mode, the texture pointer, and vertex data in CPU memory as a simple array. The vertex format is template, but a `Mesh2D` alias is provided for UGDK's `VertexXYUV`.

A Mesh can be drawn to a Canvas through `Mesh::StreamTo(Canvas&)`. In the future, this method will optimize internal `VertexData` usage to minimize draw calls to the video card.